### PR TITLE
[DDAN-60] add resource monitor, task manager recovery logic

### DIFF
--- a/experiment_scheduler/master/master.py
+++ b/experiment_scheduler/master/master.py
@@ -25,7 +25,7 @@ from experiment_scheduler.resource_monitor.resource_monitor_listener import (
 )
 from experiment_scheduler.task_manager.grpc_task_manager.task_manager_pb2 import (
     TaskStatus,
-    AllTasksStatus
+    AllTasksStatus,
 )
 
 logger = logging.getLogger()
@@ -39,6 +39,14 @@ def get_task_managers() -> List[str]:
     :return: list of address
     """
     return ast.literal_eval(USER_CONFIG.get("default", "task_manager_address"))
+
+
+def get_resource_monitors() -> List[str]:
+    """
+    Get Resource Monitor's address from experiment_scheduler.cfg
+    :return: list of address
+    """
+    return ast.literal_eval(USER_CONFIG.get("default", "resource_monitor_address"))
 
 
 class Master(MasterServicer):
@@ -89,8 +97,8 @@ class Master(MasterServicer):
         # currently only return first one
         available_task_managers = []
         for task_manager, resource_monitor in zip(
-                self.task_managers_address,
-                self.resource_monitor_listener.resource_monitor_address,
+            self.task_managers_address,
+            self.resource_monitor_listener.resource_monitor_address,
         ):
             runnable, gpu_idx = self._check_task_manager_run_task_available(
                 resource_monitor
@@ -152,7 +160,7 @@ class Master(MasterServicer):
                 request.task_id, TaskStatus.Status.NOTSTART
             )
         elif request.task_id in dict(self.running_tasks).keys():
-            print('running task!')
+            print("running task!")
             response = self.process_monitor.get_task_status(
                 self.running_tasks[request.task_id]["task_manager"], request.task_id
             )
@@ -223,8 +231,7 @@ class Master(MasterServicer):
         for tasks in self.queued_tasks:
             response.task_status_array.append(
                 self._wrap_by_task_status(
-                    task_id=tasks.task_id,
-                    status=TaskStatus.Status.NOTSTART
+                    task_id=tasks.task_id, status=TaskStatus.Status.NOTSTART
                 )
             )
         if response is None:
@@ -253,11 +260,14 @@ class Master(MasterServicer):
             dict(prior_task.task_env),
         )
         if response.status == TaskStatus.Status.RUNNING:
-            self.running_tasks[prior_task_id] = {'task': prior_task, 'task_manager': task_manager}
+            self.running_tasks[prior_task_id] = {
+                "task": prior_task,
+                "task_manager": task_manager,
+            }
         return response
 
     def _check_task_manager_run_task_available(  # pylint: disable=unused-argument,no-self-use
-            self, resource_monitor
+        self, resource_monitor
     ):
         """
         [TODO] add docstring

--- a/experiment_scheduler/resource_monitor/resource_monitor_listener.py
+++ b/experiment_scheduler/resource_monitor/resource_monitor_listener.py
@@ -27,12 +27,18 @@ class ResourceMonitorListener:  # pylint: disable=too-few-public-methods
             resource_monitor_pb2_grpc.google_dot_protobuf_dot_empty__pb2.Empty()
         )
         self.resource_monitor_address: List[str] = resource_monitor_address
-        self.resource_monitor_health_queue = dict()
+        self.resource_monitor_health_queue = self._init_resource_monitor_health_queue()
         self.resource_monitor_stubs: dict = self._get_resource_monitor_stubs()
         self.resource_monitor_health_check_thread = threading.Thread(
             target=self._health_check_resource_monitor, daemon=True
         )
         self.resource_monitor_health_check_thread.start()
+
+    def _init_resource_monitor_health_queue(self):
+        queue = dict()
+        for address in self.resource_monitor_address:
+            queue[f"is_{address}_healthy"] = False
+        return queue
 
     def _are_resource_monitors_healthy(self) -> bool:
         """
@@ -90,6 +96,8 @@ class ResourceMonitorListener:  # pylint: disable=too-few-public-methods
                 response = -1
         else:
             # must be replaced with logging
-            print(f"currently {resource_monitor_address} is not available")
+            print(
+                f"currently resource monitor {resource_monitor_address} is not available"
+            )
             response = -1
         return response


### PR DESCRIPTION
### PURPOSE OF PR
* Simple summary of this PR
* add resource monitor, task manager recovery logic
* Now, init_master can be run without caring status of rm and tm.
![image](https://user-images.githubusercontent.com/17878758/204551574-dc3a79fe-2413-4b7e-af31-61a4b330255b.png)
If tm and rm are not running on designated address, warning message will pop up.

### What type of PR is it?
* improvement


### JIRA ISSUE
* https://ddangcoonfire.atlassian.net/browse/DDAN-60


### HAVE YOU CHECKED ...
* [x] ADD JIRA ID ON PR TITLE (ex. [DDAN-1234] PR TITLE)
* [x] pre-commit (there are some probs. Those who wrote these part fix them plz. :) )
* [] Branch Format ( type/issue-NUM ) (ex. refactoring/DDAN-1234 )


### Explanation
( Adding screenshot would be great help )

### How to Test (Optional)


### Question (Optional)



### Etc (Optional)
