### PR TITLE
Make a command to compile protobuf file using current grpc-tools

### DIFF
--- a/experiment_scheduler/master/master.py
+++ b/experiment_scheduler/master/master.py
@@ -23,7 +23,7 @@ from experiment_scheduler.master.grpc_master.master_pb2 import (
     MasterResponse,
     TaskStatus,
     MasterTaskStatement,
-    TaskLogFile
+    TaskLogFile,
 )
 from experiment_scheduler.master.grpc_master.master_pb2_grpc import (
     MasterServicer,
@@ -137,7 +137,6 @@ class Master(MasterServicer):
         return MasterResponse(experiment_id=experiment_id, response=response)
 
     @start_end_logger
-    @io_logger
     def get_task_status(self, request, context):
         """
         get status certain task
@@ -172,13 +171,16 @@ class Master(MasterServicer):
         task_manager_address = self.task_managers_address[0]
         task_logfile_path = os.getcwd()
         if task_logfile_path == "":
-            yield TaskLogFile(log_file=None, error_message=bytes("Check task id", "utf-8"))
+            yield TaskLogFile(
+                log_file=None, error_message=bytes("Check task id", "utf-8")
+            )
         else:
-            for response in self.process_monitor.get_task_log(task_manager_address, request.task_id, task_logfile_path):
+            for response in self.process_monitor.get_task_log(
+                task_manager_address, request.task_id, task_logfile_path
+            ):
                 yield response
 
     @start_end_logger
-    @io_logger
     def kill_task(self, request, context):
         """
         delete certain task

--- a/experiment_scheduler/submitter/compile_protobuf.py
+++ b/experiment_scheduler/submitter/compile_protobuf.py
@@ -1,0 +1,60 @@
+import subprocess
+import re
+from pathlib import Path
+from typing import Union
+
+from experiment_scheduler.master import grpc_master
+from experiment_scheduler.task_manager import grpc_task_manager
+
+try:
+    import grpc_tools
+except ImportError:
+    grpc_tools = None
+
+
+PROTO_PATH = [grpc_master, grpc_task_manager]
+
+    
+def compile_proto_file(proto_file: Union[str, Path]):
+    proto_file = Path(proto_file)
+    subprocess.run([
+        "python", "-m", "grpc_tools.protoc",
+        f"--proto_path={proto_file.parent}",
+        f"--python_out={proto_file.parent}",
+        f"--pyi_out={proto_file.parent}",
+        f"--grpc_python_out={proto_file.parent}",
+        str(proto_file)
+    ])
+
+    pb2_grpc_file = proto_file.parent / f"{proto_file.stem}_pb2_grpc.py"
+    with pb2_grpc_file.open("r") as f:
+        lines = f.readlines()
+
+    pb2_file = f"{proto_file.stem}_pb2"
+    abs_pb2_file = pb2_file
+    for key in reversed(proto_file.parent.parts):
+        abs_pb2_file = f"{key}." + abs_pb2_file 
+        if key == "experiment_scheduler":
+            break
+
+    with pb2_grpc_file.open("w") as f:
+        for line in lines:
+            if  pb2_file in line:
+                line = re.sub(rf'{pb2_file}', rf'{abs_pb2_file}', line)
+            f.write(line)
+
+
+def main():
+    if grpc_tools is None:
+        import grpc
+        print(f"grpc_tools isn't installed. Please install grpc_tools=={grpc.__version__}")
+        return
+
+    for sub_package in PROTO_PATH:
+        pkg_using_proto = Path(sub_package.__file__).parent 
+        for proto_file in pkg_using_proto.rglob("*.proto"):
+            compile_proto_file(proto_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiment_scheduler/submitter/exs.py
+++ b/experiment_scheduler/submitter/exs.py
@@ -18,6 +18,7 @@ from experiment_scheduler.submitter.init_task_manager import (
 )
 from experiment_scheduler.submitter.list import main as exs_list
 from experiment_scheduler.submitter.status import main as exs_status
+from experiment_scheduler.submitter.compile_protobuf import main as exs_compile
 
 COMMAND_LIST = {
     "execute": exs_execute,
@@ -29,6 +30,7 @@ COMMAND_LIST = {
     "init_master": exs_init_master,
     "init_task_manager": exs_init_task_manager,
     "init_resource_monitor": exs_init_resource_monitor,
+    "grpc_compile": exs_compile,
 }
 
 HELP_MESSAGE = {


### PR DESCRIPTION
### PURPOSE OF PR
Make a command to compile protofub file using current grpc-tools.
If you need re-compile files due to code changes or conflict by grpc version,
you can easily re-compile protobuf file using `exs grpc_compile`.


### What type of PR is it?
feature



### HAVE YOU CHECKED ...
* [ ] ADD JIRA ID ON PR TITLE (ex. [DDAN-1234] PR TITLE)
* [ ] pre-commit
* [ ] Branch Format ( type/issue-NUM ) (ex. refactoring/DDAN-1234 )


### Explanation
( Adding screenshot would be great help )

### How to Test (Optional)


### Question (Optional)



### Etc (Optional)
