### PR TITLE
[DDAN-113] Bug fix exs log

### DIFF
--- a/experiment_scheduler/db_util/task_manager.py
+++ b/experiment_scheduler/db_util/task_manager.py
@@ -19,7 +19,7 @@ class TaskManager(Base, DbCommonMixin):
 
     id = Column(String(100), primary_key=True)
     address = Column(String(100))
-    log_file_path = Column(String(100), server_default="/")
+    log_file_path = Column(String(100), server_default="./")
     status = Column(Integer)
     spec = Column(JSON)
 

--- a/experiment_scheduler/master/master.py
+++ b/experiment_scheduler/master/master.py
@@ -277,15 +277,15 @@ class Master(MasterServicer):
         :return: log_file which is byte format and sent by streaming
         """
         task = TaskEntity.get(id=request.task_id)
-        task_manager = TaskManagerEntity.get(id=task.task_manager_id)
-
-        task_manager_address = task_manager.address
-        task_logfile_path = task_manager.log_file_path
-        if task_logfile_path == "":
+        if task is None:
             yield TaskLogFile(
                 log_file=None, error_message=bytes("Check task id", "utf-8")
             )
         else:
+            task_manager = TaskManagerEntity.get(id=task.task_manager_id)
+            task_manager_address = task_manager.address
+            task_logfile_path = task_manager.log_file_path
+            self.logger.info(task_logfile_path)
             for response in self.process_monitor.get_task_log(
                     task_manager_address, request.task_id, task_logfile_path
             ):

--- a/experiment_scheduler/master/master.py
+++ b/experiment_scheduler/master/master.py
@@ -285,7 +285,6 @@ class Master(MasterServicer):
             task_manager = TaskManagerEntity.get(id=task.task_manager_id)
             task_manager_address = task_manager.address
             task_logfile_path = task_manager.log_file_path
-            self.logger.info(task_logfile_path)
             for response in self.process_monitor.get_task_log(
                     task_manager_address, request.task_id, task_logfile_path
             ):

--- a/experiment_scheduler/task_manager/task_manager_server.py
+++ b/experiment_scheduler/task_manager/task_manager_server.py
@@ -32,7 +32,6 @@ logger = get_logger(name="task_manager")
 KILL_CHILD_MAX_DEPTH = 2
 CHUNK_SIZE = 1024 * 5
 
-
 class ResourceManager:
     """
     Resource Manager checks task manager's status.
@@ -204,14 +203,14 @@ class TaskManagerServicer(task_manager_pb2_grpc.TaskManagerServicer, ReturnCode)
         log_file_path = osp.join(request.log_file_path, f"{request.task_id}_log.txt")
         try:
             with open(log_file_path, mode="rb") as file:
-                IS_READ = -1
+                is_read = -1
                 while True:
                     chunk = file.read(CHUNK_SIZE)
                     if chunk:
-                        IS_READ = 1
+                        is_read = 1
                         yield TaskLogFile(log_file=chunk)
                     else:
-                        if IS_READ == -1:
+                        if is_read == -1:
                             error_message = f"There is no log in {request.task_id}"
                             yield TaskLogFile(log_file=None, error_message=bytes(error_message, "utf-8"))
                         return

--- a/experiment_scheduler/task_manager/task_manager_server.py
+++ b/experiment_scheduler/task_manager/task_manager_server.py
@@ -202,17 +202,16 @@ class TaskManagerServicer(task_manager_pb2_grpc.TaskManagerServicer, ReturnCode)
         The response is sent by streaming.
         """
         log_file_path = osp.join(request.log_file_path, f"{request.task_id}_log.txt")
-        self.logger.info(log_file_path)
         try:
             with open(log_file_path, mode="rb") as file:
-                is_read = -1
+                IS_READ = -1
                 while True:
                     chunk = file.read(CHUNK_SIZE)
                     if chunk:
-                        is_read = 1
+                        IS_READ = 1
                         yield TaskLogFile(log_file=chunk)
                     else:
-                        if is_read == -1:
+                        if IS_READ == -1:
                             error_message = f"There is no log in {request.task_id}"
                             yield TaskLogFile(log_file=None, error_message=bytes(error_message, "utf-8"))
                         return


### PR DESCRIPTION
### PURPOSE OF PR
* Simple summary of this PR
Fix the bug of 'exs log'

### What type of PR is it?
* fix / feature / improvement /  hot-fix / refactoring
Fix

### JIRA ISSUE
https://ddangcoonfire.atlassian.net/jira/software/c/projects/DDAN/boards/1?modal=detail&selectedIssue=DDAN-113

### HAVE YOU CHECKED ...
* [x] ADD JIRA ID ON PR TITLE (ex. [DDAN-1234] PR TITLE)
* [x] pre-commit
* [x] Branch Format ( type/issue-NUM ) (ex. refactoring/DDAN-1234 )


### Explanation
The reason why 'exs_log' did not run well is that the saved data of default log_file_path in task_manager table is not correct.
And if the content of log_file is empty, there is no response. So, it changes the logic and if the content of log_file is empty, the statement which announces that the log fille is empty will be appear.

### How to Test (Optional)


### Question (Optional)



### Etc (Optional)
